### PR TITLE
Updated to 7.0.0 artifacts, pull addons automatically, fixed error thrown on windows.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,10 +8,10 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up JDK 21
+      - name: Set up JDK 23
         uses: actions/setup-java@v4.7.1
         with:
-          java-version: '21'
+          java-version: '23'
           distribution: 'temurin'
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/Claude.md
+++ b/Claude.md
@@ -1,6 +1,0 @@
-Prompt from January 14th, 2026
-
-Please investigate project and resolve the error "Message: No loaders are registered for type com.dfsek.terra.api.noise.NoiseSampler" which is issued when starting the compiled program with "StartNoiseTool.bat".  Note this project can be recompiled with "gradlew.bat" and is forked from "https://github.com/PolyhedralDev/NoiseTool".
-
-After fixing:
-Addons ideally would also be imported and compiled into jar file itself instead of requiring additional "Addons" in the root folder.  These are the same addons used in "C:\Projects\BiomeTool" which currently appears to be pulling them from local maven, but they apparently are also available on solo maven, it appears here: "https://maven.solo-studios.ca/#/releases/com/dfsek"

--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,6 @@
+Prompt from January 14th, 2026
+
+Please investigate project and resolve the error "Message: No loaders are registered for type com.dfsek.terra.api.noise.NoiseSampler" which is issued when starting the compiled program with "StartNoiseTool.bat".  Note this project can be recompiled with "gradlew.bat" and is forked from "https://github.com/PolyhedralDev/NoiseTool".
+
+After fixing:
+Addons ideally would also be imported and compiled into jar file itself instead of requiring additional "Addons" in the root folder.  These are the same addons used in "C:\Projects\BiomeTool" which currently appears to be pulling them from local maven, but they apparently are also available on solo maven, it appears here: "https://maven.solo-studios.ca/#/releases/com/dfsek"

--- a/README.md
+++ b/README.md
@@ -18,19 +18,6 @@ This tool allows you to visualise and edit Terra noise configurations. Features 
 ## Setup
 
 To use the tool, simply download the latest release and run it. 
-An `addons` folder will automatically be created for you.
-The Noise Tool does not include any addons by default, so this folder will only have an empty `bootstrap` folder in it.
-
-Copy the `bootstrap` folder and the `config-noise-function` addon from your Terra installation (found in `Terra/addons`) to the Noise Tool’s `addon` folder.
-Verify that the file structure in the folder containing the Noise Tool matches this:
-
-```
-├── addons
-│   ├── bootstrap
-│   │   ├── Terra-api-addon-loader-<version>-all.jar
-│   │   └── Terra-manifest-addon-loader-<version>-all.jar
-│   └── Terra-config-noise-function-<version>-all.jar
-└── NoiseTool-<version>-all.jar
 ```
 
 Once you have verified your file structure is correct, rerun the application.

--- a/StartNoiseTool.bat
+++ b/StartNoiseTool.bat
@@ -1,0 +1,7 @@
+SET "scriptPath=%~dp0"
+set JavaHome="C:\JAVA\jdk-23\bin\java"
+
+cd "%~dp0build\libs"
+
+::%JavaHome% --add-opens=javafx.graphics/javafx.scene=ALL-UNNAMED --add-opens=jdk.unsupported/sun.misc=ALL-UNNAMED -jar BiomeTool-0.4.9-win.jar
+%JavaHome% -jar NoiseTool-1.2.1-all.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.dfsek"
-version = "1.2.1"
+version = "1.2.2"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,10 @@ version = "1.2.1"
 repositories {
     mavenCentral()
     maven {
+        name = "Solo Studios"
+        url = uri("https://maven.solo-studios.ca/releases")
+    }
+    maven {
         name = "CodeMC"
         url = uri("https://repo.codemc.org/repository/maven-public/")
     }
@@ -22,10 +26,25 @@ repositories {
     }
 }
 
+val terraGitHash = "a159debe3"
+
+val terraAddon: Configuration by configurations.creating
+val bootstrapTerraAddon: Configuration by configurations.creating
+
 dependencies {
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.13.0")
     testRuntimeOnly("org.junit.platform", "junit-platform-launcher")
-    implementation("com.dfsek.terra:base:6.6.2-BETA+af9fb211a")
+    implementation("com.dfsek:seismic:2.5.7")
+    implementation("com.dfsek.terra:api:7.0.0-BETA+$terraGitHash")
+    implementation("com.dfsek.terra:base:7.0.0-BETA+$terraGitHash")
+
+    // Bootstrap addon loaders
+    bootstrapTerraAddon("com.dfsek.terra:manifest-addon-loader:1.0.0-BETA+$terraGitHash")
+
+    // Terra addons for noise configuration
+    terraAddon("com.dfsek.terra:config-noise-function:1.2.0-BETA+$terraGitHash")
+    terraAddon("com.dfsek.terra:library-image:1.1.0-BETA+$terraGitHash")
+
     compileOnly("org.jetbrains:annotations:26.0.2")
     implementation("commons-io:commons-io:2.19.0")
     implementation("com.google.guava:guava:33.4.8-jre")
@@ -58,8 +77,29 @@ val jar by tasks.getting(Jar::class) {
     }
 }
 
+val prepareDistAddons by tasks.creating(Sync::class) {
+    group = "distribution"
+    description = "Copies Terra addons to build/libs for standalone JAR usage"
+
+    val terraAddonJars = terraAddon.resolvedConfiguration.firstLevelModuleDependencies.flatMap { dependency ->
+        dependency.moduleArtifacts.map { it.file }
+    }
+    val terraBootstrapJars = bootstrapTerraAddon.resolvedConfiguration.firstLevelModuleDependencies.flatMap { dependency ->
+        dependency.moduleArtifacts.map { it.file }
+    }
+
+    from(terraAddonJars)
+
+    from(terraBootstrapJars) {
+        into("bootstrap")
+    }
+
+    into(layout.buildDirectory.dir("libs/addons"))
+}
+
 tasks.build {
     dependsOn(tasks.named("shadowJar"))
+    finalizedBy(prepareDistAddons)
 }
 
 java {

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -73,8 +73,14 @@ goto fail
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
+if "%~1"=="" (
+	set "args=--refresh-dependencies build"
+) else (
+	set "args=%*"
+)
+
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %args%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/src/main/java/com/dfsek/noise/NoiseTool.java
+++ b/src/main/java/com/dfsek/noise/NoiseTool.java
@@ -9,7 +9,7 @@ import com.dfsek.noise.swing.StatusBar;
 import com.dfsek.noise.swing.actions.*;
 import com.dfsek.tectonic.api.config.template.object.ObjectTemplate;
 import com.dfsek.tectonic.yaml.YamlConfiguration;
-import com.dfsek.terra.api.noise.NoiseSampler;
+import com.dfsek.seismic.type.sampler.Sampler;
 import com.dfsek.terra.api.registry.Registry;
 import com.dfsek.terra.api.util.reflection.TypeKey;
 import com.formdev.flatlaf.FlatDarculaLaf;
@@ -55,7 +55,7 @@ public final class NoiseTool extends JFrame implements SearchListener {
     private FindToolBar findToolBar;
     private ReplaceToolBar replaceToolBar;
 
-    private static final TypeKey<Supplier<ObjectTemplate<NoiseSampler>>> NOISE_REGISTRY_KEY = new TypeKey<>() {};
+    private static final TypeKey<Supplier<ObjectTemplate<Sampler>>> NOISE_REGISTRY_KEY = new TypeKey<>() {};
 
 
     private NoiseTool() throws IOException {
@@ -186,7 +186,7 @@ public final class NoiseTool extends JFrame implements SearchListener {
         });
     }
 
-    private CompletionProvider createCompletionProvider(Registry<Supplier<ObjectTemplate<NoiseSampler>>> registry) {
+    private CompletionProvider createCompletionProvider(Registry<Supplier<ObjectTemplate<Sampler>>> registry) {
         DefaultCompletionProvider noiseTypeProvider = new DefaultCompletionProvider();
         noiseTypeProvider.setAutoActivationRules(true, null);
 

--- a/src/main/java/com/dfsek/noise/swing/NoisePanel.java
+++ b/src/main/java/com/dfsek/noise/swing/NoisePanel.java
@@ -3,7 +3,7 @@ package com.dfsek.noise.swing;
 import com.dfsek.noise.platform.DummyPack;
 import com.dfsek.tectonic.yaml.YamlConfiguration;
 import com.dfsek.terra.api.Platform;
-import com.dfsek.terra.api.noise.NoiseSampler;
+import com.dfsek.seismic.type.sampler.Sampler;
 import com.dfsek.terra.api.util.collection.ProbabilityCollection;
 import com.dfsek.terra.api.util.mutable.MutableBoolean;
 import net.worldsynth.glpreview.heightmap.Heightmap3DGLPreviewBufferedGL;
@@ -35,7 +35,7 @@ public class NoisePanel extends JPanel {
     private final MutableBoolean moved;
     private BufferedImage render;
 
-    private NoiseSampler noiseSeeded;
+    private Sampler noiseSeeded;
     private ProbabilityCollection<Integer> colorCollection;
     private final Platform platform;
 
@@ -169,7 +169,7 @@ public class NoisePanel extends JPanel {
         this.error.set(true);
         try {
             DummyPack pack = new DummyPack(platform, new YamlConfiguration(this.textArea.getText(), "Noise Config"), this.settingsPanel.isUseLetExpressions());
-            this.noiseSeeded = pack.getNoiseSampler();
+            this.noiseSeeded = pack.getSampler();
             this.error.set(false);
         } catch (Exception e) {
             e.printStackTrace();
@@ -198,7 +198,7 @@ public class NoisePanel extends JPanel {
         double[][] noiseVals = new double[sizeX][sizeZ];
         for (int x = 0; x < noiseVals.length; x++) {
             for (int z = 0; z < (noiseVals[x]).length; z++) {
-                double n = noiseSeeded.noise(seed, x + originX, z + originZ);
+                double n = noiseSeeded.getSample(seed, x + originX, z + originZ);
                 noiseVals[x][z] = n;
             }
         }
@@ -217,7 +217,7 @@ public class NoisePanel extends JPanel {
         for (int x = 0; x < noiseVals.length; x++) {
             for (int y = 0; y < noiseVals[x].length; y++) {
                 for(int z = 0; z < (noiseVals[x][y]).length; z++) {
-                    double n = noiseSeeded.noise(seed, x + originX, y + sampleYMin, z + originZ);
+                    double n = noiseSeeded.getSample(seed, x + originX, y + sampleYMin, z + originZ);
                     noiseVals[x][y][z] = n > 0;
                 }
             }
@@ -239,7 +239,7 @@ public class NoisePanel extends JPanel {
         long startTime = System.nanoTime();
         for (int x = 0; x < noiseVals.length; x++) {
             for (int z = 0; z < (noiseVals[x]).length; z++) {
-                double n = noiseSeeded.noise(seed, x + originX, z + originZ);
+                double n = noiseSeeded.getSample(seed, x + originX, z + originZ);
                 noiseVals[x][z] = n;
             }
         }


### PR DESCRIPTION
WARNING - PERFORMED VIA VIBE CODING
(I do not actually have java experience, but I want to use this tool to adjust yml configurations and evaluate noise configurations without having to run it through the BiomeTool.  If this is better as a branch, please let me know, but I assume the noise definitions are backwards compatible between 7 and 6.

Added automatic action for build bat file if no arguments are provided.
Added simple start bat file to launch.
Added all dependencies for 7.0.0, addons should now be pulled in automatically.
Updated build process to use Java 23.